### PR TITLE
Adds tests for failing, fixes param lookup, adds alternative

### DIFF
--- a/nautobot_plugin_nornir/plugins/credentials/env_vars.py
+++ b/nautobot_plugin_nornir/plugins/credentials/env_vars.py
@@ -5,6 +5,9 @@ from .nautobot_orm import NautobotORMCredentials
 USERNAME_ENV_VAR_NAME = "NAPALM_USERNAME"  # nosec
 PASSWORD_ENV_VAR_NAME = "NAPALM_PASSWORD"  # nosec
 SECRET_ENV_VAR_NAME = "DEVICE_SECRET"  # nosec
+ALT_USERNAME_ENV_VAR_NAME = "NAUTOBOT_NAPALM_USERNAME"  # nosec
+ALT_PASSWORD_ENV_VAR_NAME = "NAUTOBOT_NAPALM_PASSWORD"  # nosec
+ALT_SECRET_ENV_VAR_NAME = "NAUTOBOT_DEVICE_SECRET"  # nosec
 
 
 class CredentialsEnvVars(NautobotORMCredentials):
@@ -29,9 +32,9 @@ class CredentialsEnvVars(NautobotORMCredentials):
         if not isinstance(params, dict):
             raise TypeError("params must be a dictionnary")
 
-        self.username = os.getenv(params.get("username", USERNAME_ENV_VAR_NAME))
-        self.password = os.getenv(params.get("password", PASSWORD_ENV_VAR_NAME))
-        self.secret = os.getenv(params.get("secret", SECRET_ENV_VAR_NAME))
+        self.username = params.get("username", os.getenv(USERNAME_ENV_VAR_NAME, os.getenv(ALT_USERNAME_ENV_VAR_NAME)))
+        self.password = params.get("password", os.getenv(PASSWORD_ENV_VAR_NAME, os.getenv(ALT_PASSWORD_ENV_VAR_NAME)))
+        self.secret = params.get("secret", os.getenv(SECRET_ENV_VAR_NAME, os.getenv(ALT_SECRET_ENV_VAR_NAME)))
 
         if not self.secret:
             self.secret = self.password

--- a/nautobot_plugin_nornir/tests/test_nautobot_credential.py
+++ b/nautobot_plugin_nornir/tests/test_nautobot_credential.py
@@ -1,0 +1,28 @@
+"""Tests Nautobot credential."""
+import unittest
+
+from nautobot_plugin_nornir.plugins.credentials.env_vars import CredentialsEnvVars
+
+
+class TestCredentialsEnvVars(unittest.TestCase):
+    """Test of the CredentialEnvVars."""
+
+    def test_empty_vars(self):
+        """Tests empty var set."""
+        params = {}
+        test_class = CredentialsEnvVars(params=params)
+        self.assertIsNone(test_class.username)
+        self.assertIsNone(test_class.password)
+        self.assertIsNone(test_class.secret)
+
+    def test_set_vars(self):
+        """Tests environment vars being set."""
+        params = {
+            "username": "test_username",
+            "password": "test_password",
+            "secret": "test_secret",
+        }
+        test_class = CredentialsEnvVars(params=params)
+        self.assertEqual(test_class.username, "test_username")
+        self.assertEqual(test_class.password, "test_password")
+        self.assertEqual(test_class.secret, "test_secret")


### PR DESCRIPTION
When looking at the configuration I didn't quite catch what was happening. Params were previously set to be the os.getenv value, not the actual params value. This re-arranges and completes the testing for it.

This also added a second environment variable to load matching a common deployment pattern.