### PR TITLE
correct module names to nornir_nautobot in the dispatcher_mapping section of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,9 +98,9 @@ The `dispatcher_mapping` configuration option can be set to extend or map the pl
  {
   "dispatcher_mapping": {
     "newos": "dispatcher.newos",
-    "ios": "nautobot_nornir.plugins.tasks.dispatcher.cisco_ios.NautobotNornirDriver",
-    "ios_xe": "nautobot_nornir.plugins.tasks.dispatcher.cisco_ios.NautobotNornirDriver",
-    "fortinet": "nautobot_nornir.plugins.tasks.dispatcher.default.NetmikoNautobotNornirDriver",
+    "ios": "nornir_nautobot.plugins.tasks.dispatcher.cisco_ios.NautobotNornirDriver",
+    "ios_xe": "nornir_nautobot.plugins.tasks.dispatcher.cisco_ios.NautobotNornirDriver",
+    "fortinet": "nornir_nautobot.plugins.tasks.dispatcher.default.NetmikoNautobotNornirDriver",
   }
 }
 ```


### PR DESCRIPTION
There's a typo in the section on dispatcher_mapping. The previous setting in a nautobot_config.py will break backups in the Golden Config plugin (and I assume anything else that uses this plugin down the road).