### PR TITLE
Remove Args from class definition docstring

### DIFF
--- a/nautobot_plugin_nornir/plugins/credentials/env_vars.py
+++ b/nautobot_plugin_nornir/plugins/credentials/env_vars.py
@@ -12,9 +12,6 @@ class CredentialsEnvVars(MixinNautobotORMCredentials):
 
     This class is the default class that will return the same login and password
     for all devices based on the values of the environment variables
-
-    Args:
-        NautobotORMCredentials ([type]): [description]
     """
 
     def __init__(self, params=None):

--- a/nautobot_plugin_nornir/plugins/credentials/settings_vars.py
+++ b/nautobot_plugin_nornir/plugins/credentials/settings_vars.py
@@ -9,9 +9,6 @@ class CredentialsSettingsVars(MixinNautobotORMCredentials):
 
     This class will return the same login and password for all devices based on the values
     within your settings.
-
-    Args:
-        NautobotORMCredentials ([type]): [description]
     """
 
     def __init__(self, params=None):

--- a/nautobot_plugin_nornir/plugins/inventory/nautobot_orm.py
+++ b/nautobot_plugin_nornir/plugins/inventory/nautobot_orm.py
@@ -171,7 +171,7 @@ class NautobotORMInventory:
 
 
         Returns:
-            dict: Nornir Host dictionary
+            (dict): Nornir Host dictionary
         """
         host = {"data": {}}
         if "use_fqdn" in params and params.get("use_fqdn"):
@@ -229,7 +229,7 @@ class NautobotORMInventory:
             device (dcim.models.Device): Device obj
 
         Returns:
-            list: List of group names the device should be part of
+            (list): List of group names the device should be part of
         """
         groups = [
             "global",


### PR DESCRIPTION
Remove `Args` section from class definition docstring - the `__init__` docstring explains its arguments already.

Fixes the following warnings:

```
WARNING  -  griffe: nautobot_plugin_nornir/plugins/credentials/env_vars.py:17: Parameter
            'MixinNautobotORMCredentials' does not appear in the function signature
WARNING  -  griffe: nautobot_plugin_nornir/plugins/credentials/settings_vars.py:14: Parameter
            'MixinNautobotORMCredentials' does not appear in the function signature
```

Griffe expects `Args` syntax for `Returns` sections (thanks @glennmatthews !) - fixing the following warnings:

```
WARNING  -  griffe: nautobot_plugin_nornir/plugins/inventory/nautobot_orm.py:174: No type or annotation for
            returned value 'dict'
WARNING  -  griffe: nautobot_plugin_nornir/plugins/inventory/nautobot_orm.py:232: No type or annotation for
            returned value 'list'
```