### PR TITLE
deepcopy of conn_options to avoid pointers

### DIFF
--- a/nautobot_plugin_nornir/plugins/inventory/nautobot_orm.py
+++ b/nautobot_plugin_nornir/plugins/inventory/nautobot_orm.py
@@ -2,6 +2,7 @@
 # pylint: disable=unsupported-assignment-operation,unsubscriptable-object,no-member,duplicate-code
 
 from typing import Any, Dict
+from copy import deepcopy
 
 from django.db.models import QuerySet
 from django.utils.module_loading import import_string
@@ -212,7 +213,7 @@ class NautobotORMInventory:
 
         _build_out_secret_paths(conn_options, secret)
 
-        host["data"]["connection_options"] = conn_options
+        host["data"]["connection_options"] = deepcopy(conn_options)
         host["groups"] = self.get_host_groups(device=device)
 
         if device.platform.napalm_driver:


### PR DESCRIPTION
When assigning the conn_options to the host data, the options dictionaries contained pointers to global dictionaries that were re-used, causing any devices with dissimilar configuration options to be overwritten by the last host added.

This does not account for the fact that the conn_options are still being edited globally, and each device will add options to subsequent devices if they are not overwritten. That will need to be addressed separately.