### PR TITLE
bump version to 3.0.0a2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nautobot-plugin-nornir"
-version = "3.0.0a1"
+version = "3.0.0a2"
 description = "Nautobot App that provides a shim layer to simplify using Nornir within other Nautobot Apps and Nautobot Jobs"
 authors = ["Network to Code, LLC <info@networktocode.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
This is required for other apps to be able to point to the git branch. Otherwise poetry will default to pulling 3.0.0a1 from pypi