### PR TITLE
QOL Changes for `close_threaded_db_connections`

### DIFF
--- a/changes/+functools.added
+++ b/changes/+functools.added
@@ -1,0 +1,1 @@
+Added `@functools.wraps(func)` to the `close_threaded_db_connections` decorator to preserve the metadata of the wrapped function.

--- a/changes/245.fixed
+++ b/changes/245.fixed
@@ -1,0 +1,1 @@
+Fixed `close_threaded_db_connections` decorator silently discarding the return value of the wrapped function.

--- a/nautobot_plugin_nornir/db_management.py
+++ b/nautobot_plugin_nornir/db_management.py
@@ -1,5 +1,7 @@
 """Functions to manage DB related tasks."""
 
+import functools
+
 from django.db import connections
 
 from nautobot_plugin_nornir.constants import NORNIR_SETTINGS
@@ -10,6 +12,7 @@ RUNNER_SETTINGS = NORNIR_SETTINGS.get("runner", {})
 def close_threaded_db_connections(func):
     """Decorator that clears idle DB connections in thread."""
 
+    @functools.wraps(func)
     def inner(*args, **kwargs):
         """Inner function."""
         try:

--- a/nautobot_plugin_nornir/db_management.py
+++ b/nautobot_plugin_nornir/db_management.py
@@ -13,8 +13,7 @@ def close_threaded_db_connections(func):
     def inner(*args, **kwargs):
         """Inner function."""
         try:
-            func(*args, **kwargs)
-
+            return func(*args, **kwargs)
         finally:
             # Only clear DB connections if plays are threaded
             if RUNNER_SETTINGS.get("plugin") == "threaded":

--- a/nautobot_plugin_nornir/tests/test_db_management.py
+++ b/nautobot_plugin_nornir/tests/test_db_management.py
@@ -1,0 +1,51 @@
+"""Unit tests for the close_threaded_db_connections decorator (issue #245)."""
+
+from unittest import mock
+
+from django.test import TestCase
+
+from nautobot_plugin_nornir import db_management
+from nautobot_plugin_nornir.db_management import close_threaded_db_connections
+
+
+class CloseThreadedDBConnectionsTests(TestCase):
+    """Tests for close_threaded_db_connections decorator return semantics and cleanup."""
+
+    @mock.patch.object(db_management.connections, "close_all")
+    @mock.patch.dict(db_management.RUNNER_SETTINGS, {"plugin": "threaded"}, clear=True)
+    def test_returns_wrapped_value_when_threaded(self, mock_close_all):
+        @close_threaded_db_connections
+        def task():
+            return {"payload": "data"}
+
+        self.assertEqual(task(), {"payload": "data"})
+        mock_close_all.assert_called_once()
+
+    @mock.patch.object(db_management.connections, "close_all")
+    @mock.patch.dict(db_management.RUNNER_SETTINGS, {"plugin": "serial"}, clear=True)
+    def test_returns_wrapped_value_when_not_threaded(self, mock_close_all):
+        @close_threaded_db_connections
+        def task():
+            return 42
+
+        self.assertEqual(task(), 42)
+        mock_close_all.assert_not_called()
+
+    @mock.patch.object(db_management.connections, "close_all")
+    @mock.patch.dict(db_management.RUNNER_SETTINGS, {"plugin": "threaded"}, clear=True)
+    def test_exception_propagates_and_connections_closed(self, mock_close_all):
+        @close_threaded_db_connections
+        def task():
+            raise ValueError("boom")
+
+        with self.assertRaises(ValueError):
+            task()
+        mock_close_all.assert_called_once()
+
+    def test_wraps_preserves_metadata(self):
+        @close_threaded_db_connections
+        def my_task():
+            """My task docstring."""
+
+        self.assertEqual(my_task.__name__, "my_task")
+        self.assertEqual(my_task.__doc__, "My task docstring.")


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot Nornir Plugin! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #245

## What's Changed
This PR adds two changes to `close_threaded_db_connections`.
- We now return the result of the wrapped function
- We now preserve the metadata of the wrapped function (instead of showing up as `inner`)

```python
# Before
In [1]: from nautobot_plugin_nornir.db_management import close_threaded_db_connections

In [2]: @close_threaded_db_connections
   ...: def my_task():
   ...:     return {"hostname": "device1", "payload": "important data"}
   ...:

In [3]: print(repr(my_task()))
None

# After
In [1]: from nautobot_plugin_nornir.db_management import close_threaded_db_connections

In [2]: @close_threaded_db_connections
   ...: def my_task():
   ...:     return {"hostname": "device1", "payload": "important data"}
   ...:

In [3]: print(repr(my_task()))
{'hostname': 'device1', 'payload': 'important data'}
```

## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests

NTC-5096