### PR TITLE
Fix YAML indentation in Device Type Config Context docs example

### DIFF
--- a/changes/267.fixed
+++ b/changes/267.fixed
@@ -1,0 +1,1 @@
+Fixed YAML indentation in the Device Type Config Context example in the inventory documentation.

--- a/docs/user/app_feature_inventory.md
+++ b/docs/user/app_feature_inventory.md
@@ -54,9 +54,9 @@ _metadata:
 nautobot_plugin_nornir:
   connection_options:
     napalm:
-    extras:
+      extras:
         optional_args:
-        global_delay_factor: 5
+          global_delay_factor: 5
 ```
 
 ## Inventory Groupings


### PR DESCRIPTION
# Closes: #267

## What's Changed

Corrects the YAML nesting of `extras:`, `optional_args:`, and `global_delay_factor:` in the "Device Type Config Context" example in `docs/user/app_feature_inventory.md`. The previous example rendered them as siblings instead of properly nested children, which would not produce the documented behavior. The fixed example now matches the structure of the JSON "Local Device Config Context" example shown immediately above it.

### Before

```yaml
nautobot_plugin_nornir:
  connection_options:
    napalm:
    extras:
        optional_args:
        global_delay_factor: 5
```

### After

```yaml
nautobot_plugin_nornir:
  connection_options:
    napalm:
      extras:
        optional_args:
          global_delay_factor: 5
```

## To Do
- [x] Explanation of Change(s)
- [x] Added change log fragment(s)
- [ ] Attached Screenshots, Payload Example — N/A (docs-only diff)
- [ ] Unit, Integration Tests — N/A (docs-only)
- [x] Documentation Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design — none